### PR TITLE
Fix - Eliminazione storia elimina anche StatoPartita associati

### DIFF
--- a/src/main/java/com/progettosweng/application/repository/StatoPartitaRepository.java
+++ b/src/main/java/com/progettosweng/application/repository/StatoPartitaRepository.java
@@ -58,4 +58,10 @@ public interface StatoPartitaRepository extends JpaRepository<StatoPartita, Long
      */
     @Query("SELECT sp.scenario.idScenario FROM StatoPartita sp WHERE sp.username = :username AND sp.storia = :storia")
     Integer findScenarioIdById(@Param("username") String username, @Param("storia") Storia storia);
+
+    /**
+     * Elimina tutte le partite salvate associate a una storia specificata.
+     * @param storia la storia
+     */
+    void deleteByStoria(Storia storia);
 }

--- a/src/main/java/com/progettosweng/application/service/StatoPartitaService.java
+++ b/src/main/java/com/progettosweng/application/service/StatoPartitaService.java
@@ -127,4 +127,6 @@ public class StatoPartitaService {
     public int getStoriaId(StatoPartita statoPartita) {
         return statoPartita.getStoria().getIdStoria();
     }
+
+    public void deleteStatoPartitaByStoria(Storia storia) { statoPartitaRepository.deleteByStoria(storia); }
 }

--- a/src/main/java/com/progettosweng/application/service/StoriaService.java
+++ b/src/main/java/com/progettosweng/application/service/StoriaService.java
@@ -22,6 +22,7 @@ public class StoriaService {
     private final InventarioService inventarioService;
     private final SceltaIndovinelloService sceltaIndovinelloService;
     private final SceltaSempliceService sceltaSempliceService;
+    private final StatoPartitaService statoPartitaService;
 
     @Autowired
     public StoriaService(StoriaRepository storiaRepository,
@@ -30,7 +31,8 @@ public class StoriaService {
                          OggettoService oggettoService,
                          InventarioService inventarioService,
                          SceltaIndovinelloService sceltaIndovinelloService,
-                         SceltaSempliceService sceltaSempliceService){
+                         SceltaSempliceService sceltaSempliceService,
+                         StatoPartitaService statoPartitaService){
         this.repository = storiaRepository;
         this.scenarioService = scenarioService;
         this.collegamentoService = collegamentoService;
@@ -38,6 +40,7 @@ public class StoriaService {
         this.inventarioService = inventarioService;
         this.sceltaIndovinelloService = sceltaIndovinelloService;
         this.sceltaSempliceService = sceltaSempliceService;
+        this.statoPartitaService = statoPartitaService;
     }
 
     /**
@@ -55,6 +58,7 @@ public class StoriaService {
      */
     @Transactional
     public void deleteStoria(Storia storia) {
+        statoPartitaService.deleteStatoPartitaByStoria(storia);
         inventarioService.deleteInventarioByStoria(storia);
         sceltaSempliceService.deleteSceltaSempliceByStoria(storia);
         sceltaIndovinelloService.deleteSceltaIndovinelloByStoria(storia);

--- a/src/main/java/com/progettosweng/application/views/scrittura/ImpostazioniScenario.java
+++ b/src/main/java/com/progettosweng/application/views/scrittura/ImpostazioniScenario.java
@@ -261,7 +261,7 @@ public class ImpostazioniScenario extends VerticalLayout {
         comboBoxScelta.addValueChangeListener(event -> {
             verticalLayout.removeAll();
             verticalLayout.add(titoloCollegamento, nomeScelta, comboBoxScenario, comboBoxScelta);
-            String selezione = event.getValue(); // Use getValue() instead of getHasValue().toString()
+            String selezione = event.getValue();
             if ("Scelta semplice".equals(selezione)) {
                 Button salvaCollegamentoSemplice = new Button("Salva collegamento", e -> SalvaCollegamentoSemplice());
                 verticalLayout.add(salvaCollegamentoSemplice);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -16,5 +16,5 @@ spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect
 # To improve the performance during development.
 # For more information https://vaadin.com/docs/latest/integrations/spring/configuration#special-configuration-parameters
 vaadin.allowed-packages = com.vaadin,org.vaadin,dev.hilla,com.prova.application
-spring.jpa.defer-datasource-initialization = true
+spring.jpa.defer-datasource-initialization=true
 vaadin.frontend.frontend-folder=src/main/java/com/progettosweng/application/views/style


### PR DESCRIPTION
L'eliminazione della storia non funzionava quando vi erano delle partite in corso. Ho quindi aggiunto un metodo che elimina tutti gli statiPartita associati a una storia e l'ho aggiunto in deleteStoria di storiaService.